### PR TITLE
feat: add support for hugo summary

### DIFF
--- a/ansibledoctor/templates/hugo-book/index.md.j2
+++ b/ansibledoctor/templates/hugo-book/index.md.j2
@@ -3,12 +3,17 @@
 ---
 title: {{ meta.name.value | save_join(" ") }}
 type: docs
+{% if summary | deep_get(meta, "summary.value") %}
+summary: {{ meta.summary.value | save_join(" ") }}
+{% endif %}
 ---
 {% endif %}
 {% if description | deep_get(meta, "description.value") %}
 
 {{ meta.description.value | save_join(" ") }}
 {% endif %}
+
+<!--more-->
 
 {#      TOC      #}
 {% include '_toc.j2' %}


### PR DESCRIPTION
The default theme `hugo-book` will add the `summary` parameter to the generated front matter if `@meta summary:`  annotation is set. As a fallback, a manual summary split was added in front of the ToC. 