### PR TITLE
fix: use custom method for annotation split to allow escape chars

### DIFF
--- a/ansibledoctor/annotation.py
+++ b/ansibledoctor/annotation.py
@@ -98,7 +98,7 @@ class Annotation:
         line1 = re.sub(reg1, "", line).strip()
 
         # step3 take the main key value from the annotation
-        parts = [part.strip() for part in line1.split(":", 2)]
+        parts = [part.strip() for part in self._split_string(line1, ":", "\\", 2)]
         key = str(parts[0])
         item.data[key] = {}
         multiline_char = [">", "$>"]
@@ -183,3 +183,36 @@ class Annotation:
                     rfile, str(num), line.strip()
                 )
             )
+
+    def _split_string(self, string, delimiter, escape, maxsplit=None):
+        result = []
+        current_element = []
+        iterator = iter(string)
+        count_split = 0
+        skip_split = False
+
+        for character in iterator:
+            if maxsplit and count_split >= maxsplit:
+                skip_split = True
+
+            if character == escape and not skip_split:
+                try:
+                    next_character = next(iterator)
+                    if next_character != delimiter and next_character != escape:
+                        # Do not copy the escape character if it is intended to escape either the
+                        # delimiter or the escape character itself. Copy the escape character
+                        # if it is not used to escape either of these characters.
+                        current_element.append(escape)
+                    current_element.append(next_character)
+                    count_split += 1
+                except StopIteration:
+                    current_element.append(escape)
+            elif character == delimiter and not skip_split:
+                result.append("".join(current_element))
+                current_element = []
+                count_split += 1
+            else:
+                current_element.append(character)
+
+        result.append("".join(current_element))
+        return result

--- a/ansibledoctor/annotation.py
+++ b/ansibledoctor/annotation.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import anyconfig
 
 from ansibledoctor.config import SingleConfig
-from ansibledoctor.utils import SingleLog
+from ansibledoctor.utils import SingleLog, _split_string
 
 
 class AnnotationItem:
@@ -98,7 +98,7 @@ class Annotation:
         line1 = re.sub(reg1, "", line).strip()
 
         # step3 take the main key value from the annotation
-        parts = [part.strip() for part in self._split_string(line1, ":", "\\", 2)]
+        parts = [part.strip() for part in _split_string(line1, ":", "\\", 2)]
         key = str(parts[0])
         item.data[key] = {}
         multiline_char = [">", "$>"]
@@ -183,36 +183,3 @@ class Annotation:
                     rfile, str(num), line.strip()
                 )
             )
-
-    def _split_string(self, string, delimiter, escape, maxsplit=None):
-        result = []
-        current_element = []
-        iterator = iter(string)
-        count_split = 0
-        skip_split = False
-
-        for character in iterator:
-            if maxsplit and count_split >= maxsplit:
-                skip_split = True
-
-            if character == escape and not skip_split:
-                try:
-                    next_character = next(iterator)
-                    if next_character != delimiter and next_character != escape:
-                        # Do not copy the escape character if it is intended to escape either the
-                        # delimiter or the escape character itself. Copy the escape character
-                        # if it is not used to escape either of these characters.
-                        current_element.append(escape)
-                    current_element.append(next_character)
-                    count_split += 1
-                except StopIteration:
-                    current_element.append(escape)
-            elif character == delimiter and not skip_split:
-                result.append("".join(current_element))
-                current_element = []
-                count_split += 1
-            else:
-                current_element.append(character)
-
-        result.append("".join(current_element))
-        return result

--- a/ansibledoctor/utils.py
+++ b/ansibledoctor/utils.py
@@ -41,6 +41,40 @@ def _should_do_markup():
     return sys.stdout.isatty() and os.environ.get("TERM") != "dumb"
 
 
+def _split_string(string, delimiter, escape, maxsplit=None):
+    result = []
+    current_element = []
+    iterator = iter(string)
+    count_split = 0
+    skip_split = False
+
+    for character in iterator:
+        if maxsplit and count_split >= maxsplit:
+            skip_split = True
+
+        if character == escape and not skip_split:
+            try:
+                next_character = next(iterator)
+                if next_character != delimiter and next_character != escape:
+                    # Do not copy the escape character if it is intended to escape either the
+                    # delimiter or the escape character itself. Copy the escape character
+                    # if it is not used to escape either of these characters.
+                    current_element.append(escape)
+                current_element.append(next_character)
+                count_split += 1
+            except StopIteration:
+                current_element.append(escape)
+        elif character == delimiter and not skip_split:
+            result.append("".join(current_element))
+            current_element = []
+            count_split += 1
+        else:
+            current_element.append(character)
+
+    result.append("".join(current_element))
+    return result
+
+
 colorama.init(autoreset=True, strip=not _should_do_markup())
 
 

--- a/docs/content/usage/getting-started.md
+++ b/docs/content/usage/getting-started.md
@@ -33,7 +33,7 @@ option1
 # the default description with an annotation.
 # @end
 
-# @meta author: [John Doe](https://blog.example.com)
+# @meta author:value: [John Doe](https://blog.example.com)
 ```
 
 ### `@var`

--- a/example/README.md
+++ b/example/README.md
@@ -178,4 +178,4 @@ MIT
 
 ## Author
 
-John Doe
+[John Doe](https://blog.example.com)

--- a/example/demo-role/meta/main.yml
+++ b/example/demo-role/meta/main.yml
@@ -3,7 +3,7 @@
 # Role to demonstrate ansible-doctor. It is also possible to overwrite
 # the default description with an annotation.
 # @end
-# @meta author: [John Doe](https://blog.example.com)
+# @meta author: [John Doe](https\://blog.example.com)
 galaxy_info:
   description: Role to demonstrate ansible-doctor.
   author: John Doe


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/ansible-doctor/issues/367

This PR adds the ability to escape `:`  chars to avoid annotation splits at the wrong position. Example:

```
# @meta author:value: [John Doe](https://blog.example.com)

or escape the first `:` while using the short-hand annotation

# @meta author: [John Doe](https\://blog.example.com)
```