### PR TITLE
fix: use poetry-dynamic-versioning for PEP 517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ filterwarnings = [
 omit = ["**/test/*"]
 
 [build-system]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.backend"
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 
 [tool.ruff]


### PR DESCRIPTION
I'm working on building this package in [nixpkgs](https://github.com/NixOS/nixpkgs) using a PEP 517 front-end ([build](https://pypa-build.readthedocs.io/en/latest/)) and learned that, [according to the README](https://github.com/mtkennerly/poetry-dynamic-versioning#installation), the build system backend should be a wrapper from poetry-dynamic-versioning. Hope this makes sense.