### PR TITLE
fix: allow ansible-core versions newer than 2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pathspec = "0.12.1"
 python = "^3.8.0"
 python-json-logger = "2.0.7"
 "ruamel.yaml" = "0.18.5"
-ansible-core = "2.13"
+ansible-core = "^2.13"
 
 [tool.poetry.scripts]
 ansible-doctor = "ansibledoctor.cli:main"


### PR DESCRIPTION
ansible-core 2.13 and the corresponding ansible 6.0.0 had been deprecated. This allows users to use ansible-doctor with any modern enough version of ansible, while not breaking legacy setups.

https://github.com/thegeeklab/ansible-doctor/issues/623