### PR TITLE
fix: make `ansible-core` an optional extra-dependency

### DIFF
--- a/.woodpecker/lint.yml
+++ b/.woodpecker/lint.yml
@@ -10,7 +10,7 @@ steps:
     image: docker.io/library/python:3.12
     commands:
       - pip install poetry poetry-dynamic-versioning -qq
-      - poetry install
+      - poetry install -E ansible-core
       - poetry run ruff format --check --diff ./${CI_REPO_NAME//-/}
     environment:
       PY_COLORS: "1"
@@ -19,7 +19,7 @@ steps:
     image: docker.io/library/python:3.12
     commands:
       - pip install poetry poetry-dynamic-versioning -qq
-      - poetry install
+      - poetry install -E ansible-core
       - poetry run ruff ./${CI_REPO_NAME//-/}
     environment:
       PY_COLORS: "1"

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -10,7 +10,7 @@ variables:
     group: pytest
     commands:
       - pip install poetry poetry-dynamic-versioning -qq
-      - poetry install
+      - poetry install -E ansible-core
       - poetry version
       - poetry run ${CI_REPO_NAME} --help
     environment:

--- a/Containerfile.multiarch
+++ b/Containerfile.multiarch
@@ -14,7 +14,7 @@ ADD dist/ansible_doctor-*.whl /
 
 RUN apk --update add --virtual .build-deps build-base libffi-dev openssl-dev && \
     pip install --upgrade --no-cache-dir pip && \
-    pip install --no-cache-dir $(find / -name "ansible_doctor-*.whl") && \
+    pip install --no-cache-dir $(find / -name "ansible_doctor-*.whl")[ansible-core] && \
     rm -f ansible_doctor-*.whl && \
     rm -rf /var/cache/apk/* && \
     rm -rf /root/.cache/

--- a/ansibledoctor/__init__.py
+++ b/ansibledoctor/__init__.py
@@ -1,3 +1,10 @@
 """Provide version information."""
 
 __version__ = "0.0.0"
+
+import sys
+
+try:
+    import ansible  # noqa
+except ImportError:
+    sys.exit("ERROR: Python requirements are missing: 'ansible-core' not found.")

--- a/ansibledoctor/utils/yamlhelper.py
+++ b/ansibledoctor/utils/yamlhelper.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from contextlib import suppress
 
 import ruamel.yaml
-import yaml
 from ansible.parsing.yaml.loader import AnsibleLoader
 
 import ansibledoctor.exception
@@ -28,10 +27,10 @@ def parse_yaml_ansible(yamlfile):
         loader = AnsibleLoader(yamlfile)
         data = loader.get_single_data() or []
     except (
-        yaml.parser.ParserError,
-        yaml.scanner.ScannerError,
-        yaml.constructor.ConstructorError,
-        yaml.composer.ComposerError,
+        ruamel.yaml.parser.ParserError,
+        ruamel.yaml.scanner.ScannerError,
+        ruamel.yaml.constructor.ConstructorError,
+        ruamel.yaml.composer.ComposerError,
     ) as e:
         message = (
             f"{e.context} in line {e.context_mark.line}, column {e.context_mark.line}\n"

--- a/docs/content/setup/pip.md
+++ b/docs/content/setup/pip.md
@@ -10,5 +10,6 @@ $ pip install ansible-doctor[ansible-core] --user
 $ sudo pip install ansible-doctor[ansible-core]
 
 # From Wheel file
-$ pip install https://github.com/thegeeklab/ansible-doctor/releases/download/v0.1.1/ansible_doctor-0.1.1-py2.py3-none-any.whl[ansible-core]
+# Please check first whether a newer version is available.
+$ pip install https://github.com/thegeeklab/ansible-doctor/releases/download/v3.1.4/ansible_doctor-3.1.4-py2.py3-none-any.whl[ansible-core]
 ```

--- a/docs/content/setup/pip.md
+++ b/docs/content/setup/pip.md
@@ -4,11 +4,11 @@ title: Using pip
 
 ```Shell
 # From PyPI as unprivileged user
-$ pip install ansible-doctor --user
+$ pip install ansible-doctor[ansible-core] --user
 
 # .. or as root
-$ sudo pip install ansible-doctor
+$ sudo pip install ansible-doctor[ansible-core]
 
 # From Wheel file
-$ pip install https://github.com/thegeeklab/ansible-doctor/releases/download/v0.1.1/ansible_doctor-0.1.1-py2.py3-none-any.whl
+$ pip install https://github.com/thegeeklab/ansible-doctor/releases/download/v0.1.1/ansible_doctor-0.1.1-py2.py3-none-any.whl[ansible-core]
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "ansible-core"
 version = "2.13.13"
 description = "Radically simple IT automation"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "ansible-core-2.13.13.tar.gz", hash = "sha256:7ad2d8c0a5fa4a59de1809a5f96d2dbf511189c834116f5c72aec9730b51074b"},
@@ -73,7 +73,7 @@ tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "p
 name = "cffi"
 version = "1.16.0"
 description = "Foreign Function Interface for Python calling C code."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
@@ -215,7 +215,7 @@ toml = ["tomli"]
 name = "cryptography"
 version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf"},
@@ -506,7 +506,7 @@ testing = ["pytest", "pytest-benchmark"]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -599,7 +599,7 @@ files = [
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
@@ -663,7 +663,7 @@ rpds-py = ">=0.7.0"
 name = "resolvelib"
 version = "0.8.1"
 description = "Resolve abstract dependencies into concrete ones"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "resolvelib-0.8.1-py2.py3-none-any.whl", hash = "sha256:d9b7907f055c3b3a2cfc56c914ffd940122915826ff5fb5b1de0c99778f4de98"},
@@ -926,7 +926,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+ansible-core = ["ansible-core"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "d2e94cf03d74fd86cb10951572cab6dc87c1e0d3d0693041971896f2769ddffc"
+content-hash = "b6d497e45a5bcff165a5f33623b6665b11b0f0e4822728d7914b8bfd3e60c28b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ pathspec = "0.12.1"
 python = "^3.8.0"
 python-json-logger = "2.0.7"
 "ruamel.yaml" = "0.18.5"
-ansible-core = "^2.13"
+ansible-core = {version = "2.13.13", optional = true}
+
+[tool.poetry.extras]
+ansible-core = ["ansible-core"]
 
 [tool.poetry.scripts]
 ansible-doctor = "ansibledoctor.cli:main"


### PR DESCRIPTION
This way `ansible-core` can be installed from other sources (e.g. distro packages) as well, and it's not required to use the version shipped with `ansible-doctor`.