### PR TITLE
feat: add option for tabulating variables

### DIFF
--- a/ansibledoctor/config.py
+++ b/ansibledoctor/config.py
@@ -123,6 +123,12 @@ class Config:
             "file": True,
             "type": environs.Env().bool,
         },
+        "tabulate_variables": {
+            "default": False,
+            "env": "TABULATE_VARIABLES",
+            "file": True,
+            "type": environs.Env().bool,
+        },
     }
 
     ANNOTATIONS = {

--- a/ansibledoctor/doc_generator.py
+++ b/ansibledoctor/doc_generator.py
@@ -125,9 +125,7 @@ class Generator:
                             jenv.filters["save_join"] = self._safe_join
                             tabulate_vars = self.config.config.get("tabulate_variables")
                             data = jenv.from_string(data).render(
-                                role_data,
-                                role=role_data,
-                                tabulate_vars=tabulate_vars
+                                role_data, role=role_data, tabulate_vars=tabulate_vars
                             )
                             if not self.config.config["dry_run"]:
                                 with open(doc_file, "wb") as outfile:

--- a/ansibledoctor/doc_generator.py
+++ b/ansibledoctor/doc_generator.py
@@ -123,7 +123,12 @@ class Generator:
                             jenv.filters["safe_join"] = self._safe_join
                             # keep the old name of the function to not break custom templates.
                             jenv.filters["save_join"] = self._safe_join
-                            data = jenv.from_string(data).render(role_data, role=role_data)
+                            tabulate_vars = self.config.config.get("tabulate_variables")
+                            data = jenv.from_string(data).render(
+                                role_data,
+                                role=role_data,
+                                tabulate_vars=tabulate_vars
+                            )
                             if not self.config.config["dry_run"]:
                                 with open(doc_file, "wb") as outfile:
                                     outfile.write(header_content.encode("utf-8"))

--- a/ansibledoctor/templates/hugo-book/_toc.j2
+++ b/ansibledoctor/templates/hugo-book/_toc.j2
@@ -2,9 +2,11 @@
 {% set var = role.var | default({}) %}
 {% if var %}
 - [Default Variables](#default-variables)
+{% if not tabulate_vars %}
 {% for key, item in var | dictsort %}
   - [{{ key }}](#{{ key }})
 {% endfor %}
+{% endif %}
 {% endif %}
 {% if tag %}
 - [Discovered Tags](#discovered-tags)

--- a/ansibledoctor/templates/hugo-book/_vars_tabulated.j2
+++ b/ansibledoctor/templates/hugo-book/_vars_tabulated.j2
@@ -12,7 +12,7 @@
 |
 {% for c in columns %}
 {% if c in found_columns %}
-| {{ "-" * c | length }} {# trimnewline #}
+| {{ "-" * (c | length) }} {# trimnewline #}
 {% endif %}
 {% endfor %}
 |

--- a/ansibledoctor/templates/hugo-book/_vars_tabulated.j2
+++ b/ansibledoctor/templates/hugo-book/_vars_tabulated.j2
@@ -1,0 +1,36 @@
+{% set var = role.var | default({}) %}
+{% if var %}
+## Default Variables
+
+{% set columns = ["variable", "default", "description", "type", "deprecated", "example"] %}
+{% set found_columns = ["variable", "default"] + var.values() | map("list") | sum(start=["key"]) | unique | list %}
+{% for c in columns %}
+{% if c in found_columns %}
+| {{ c | capitalize }} {# trimnewline #}
+{% endif %}
+{% endfor %}
+|
+{% for c in columns %}
+{% if c in found_columns %}
+| {{ "-" * c | length }} {# trimnewline #}
+{% endif %}
+{% endfor %}
+|
+{% for key, item in var | dictsort %}
+| {{ key }} {# trimnewline #}
+| {{ (item.value | default({}))[key] | default }} {# trimnewline #}
+{% if "description" in found_columns %}
+| {{ item.description | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
+{% endif %}
+{% if "type" in found_columns %}
+| {{ item.type | default([]) | join("<br>") }} {# trimnewline #}
+{% endif %}
+{% if "deprecated" in found_columns %}
+| {{ item.deprecated | default }} {# trimnewline #}
+{% endif %}
+{% if "example" in found_columns %}
+| {{ item.example | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
+{% endif %}
+|
+{% endfor %}
+{% endif %}

--- a/ansibledoctor/templates/hugo-book/index.md.j2
+++ b/ansibledoctor/templates/hugo-book/index.md.j2
@@ -23,7 +23,11 @@ summary: {{ meta.summary.value | safe_join(" ") }}
 {% include '_requirements.j2' %}
 
 {#      Vars      #}
+{% if tabulate_vars %}
+{% include '_vars_tabulated.j2' %}
+{% else %}
 {% include '_vars.j2' %}
+{% endif %}
 
 {#      Tag      #}
 {% include '_tag.j2' %}

--- a/ansibledoctor/templates/readme/README.md.j2
+++ b/ansibledoctor/templates/readme/README.md.j2
@@ -15,7 +15,11 @@
 {% include '_requirements.j2' %}
 
 {#      Vars      #}
-{% include '_vars.j2' %}
+{% if tabulate_vars %}
+{%     include '_vars_tabulated.j2' %}
+{% else %}
+{%     include '_vars.j2' %}
+{% endif %}
 
 {#      Tag      #}
 {% include '_tag.j2' %}

--- a/ansibledoctor/templates/readme/README.md.j2
+++ b/ansibledoctor/templates/readme/README.md.j2
@@ -16,9 +16,9 @@
 
 {#      Vars      #}
 {% if tabulate_vars %}
-{%     include '_vars_tabulated.j2' %}
+{% include '_vars_tabulated.j2' %}
 {% else %}
-{%     include '_vars.j2' %}
+{% include '_vars.j2' %}
 {% endif %}
 
 {#      Tag      #}

--- a/ansibledoctor/templates/readme/_toc.j2
+++ b/ansibledoctor/templates/readme/_toc.j2
@@ -4,9 +4,11 @@
 {% set var = role.var | default({}) %}
 {% if var %}
 - [Default Variables](#default-variables)
-{% for key, item in var | dictsort %}
+{%     if not tabulate_vars %}
+{%         for key, item in var | dictsort %}
   - [{{ key }}](#{{ key }})
-{% endfor %}
+{%         endfor %}
+{%     endif %}
 {% endif %}
 {% if tag %}
 - [Discovered Tags](#discovered-tags)

--- a/ansibledoctor/templates/readme/_toc.j2
+++ b/ansibledoctor/templates/readme/_toc.j2
@@ -4,11 +4,11 @@
 {% set var = role.var | default({}) %}
 {% if var %}
 - [Default Variables](#default-variables)
-{%     if not tabulate_vars %}
-{%         for key, item in var | dictsort %}
+{% if not tabulate_vars %}
+{% for key, item in var | dictsort %}
   - [{{ key }}](#{{ key }})
-{%         endfor %}
-{%     endif %}
+{% endfor %}
+{% endif %}
 {% endif %}
 {% if tag %}
 - [Discovered Tags](#discovered-tags)

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -1,0 +1,38 @@
+{% set var = role.var | default({}) %}
+{% if var %}
+## Default Variables
+
+{%     set columns = ["variable", "default", "description", "type", "deprecated", "example"] %}
+{%     set found_columns = ["variable", "default"] + var.values() | map("list") | sum(start=["key"]) | unique | list %}
+{%     for c in columns %}
+{%         if c in found_columns %}
+| {{ c | capitalize }} {% if loop.last %}|{% endif %}
+{%         endif %}
+{%     endfor +%}
+{%     for c in columns %}
+{%         if c in found_columns %}
+| {{ "-" * c | length }} {% if loop.last %}|{% endif %}
+{%         endif %}
+{%     endfor %}
+{%     for key, item in var | dictsort %}
+
+| {{ key }} {# trimnewline #}
+{%         if "default" in found_columns %}
+| {{ item.value[key] }} {# trimnewline #}
+{%         endif %}
+{%         if "description" in found_columns %}
+| {{ item.description | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
+{%         endif %}
+{%         if "type" in found_columns %}
+| {{ item.type | first }} {# trimnewline #}
+{%         endif %}
+{%         if "deprecated" in found_columns %}
+| {{ item.deprecated }} {# trimnewline #}
+{%         endif %}
+{%         if "example" in found_columns %}
+| {{ item.example | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
+{%         endif %}
+| {# trimnewline #}
+{%     endfor %}
+
+{% endif %}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -18,7 +18,7 @@
 |
 {%     for key, item in var | dictsort %}
 | {{ key }} {# trimnewline #}
-| {{ item.value[key] | default }} {# trimnewline #}
+| {{ (item.value | default({}))[key] | default }} {# trimnewline #}
 {%         if "description" in found_columns %}
 | {{ item.description | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
 {%         endif %}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -18,20 +18,18 @@
 |
 {%     for key, item in var | dictsort %}
 | {{ key }} {# trimnewline #}
-{%         if "default" in found_columns %}
-| {{ item.value[key] }} {# trimnewline #}
-{%         endif %}
+| {{ item.value[key] | default }} {# trimnewline #}
 {%         if "description" in found_columns %}
-| {{ item.description | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
+| {{ item.description | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
 {%         endif %}
 {%         if "type" in found_columns %}
-| {{ item.type | first }} {# trimnewline #}
+| {{ item.type | default([]) | join("<br>") }} {# trimnewline #}
 {%         endif %}
 {%         if "deprecated" in found_columns %}
-| {{ item.deprecated }} {# trimnewline #}
+| {{ item.deprecated | default }} {# trimnewline #}
 {%         endif %}
 {%         if "example" in found_columns %}
-| {{ item.example | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
+| {{ item.example | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
 {%         endif %}
 |
 {%     endfor %}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -6,16 +6,17 @@
 {%     set found_columns = ["variable", "default"] + var.values() | map("list") | sum(start=["key"]) | unique | list %}
 {%     for c in columns %}
 {%         if c in found_columns %}
-| {{ c | capitalize }} {% if loop.last %}|{% endif %}
-{%         endif %}
-{%     endfor +%}
-{%     for c in columns %}
-{%         if c in found_columns %}
-| {{ "-" * c | length }} {% if loop.last %}|{% endif %}
+| {{ c | capitalize }} {# trimnewline #}
 {%         endif %}
 {%     endfor %}
+|
+{%     for c in columns %}
+{%         if c in found_columns %}
+| {{ "-" * c | length }} {# trimnewline #}
+{%         endif %}
+{%     endfor %}
+|
 {%     for key, item in var | dictsort %}
-
 | {{ key }} {# trimnewline #}
 {%         if "default" in found_columns %}
 | {{ item.value[key] }} {# trimnewline #}
@@ -32,7 +33,6 @@
 {%         if "example" in found_columns %}
 | {{ item.example | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
 {%         endif %}
-| {# trimnewline #}
+|
 {%     endfor %}
-
 {% endif %}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -2,35 +2,35 @@
 {% if var %}
 ## Default Variables
 
-{%     set columns = ["variable", "default", "description", "type", "deprecated", "example"] %}
-{%     set found_columns = ["variable", "default"] + var.values() | map("list") | sum(start=["key"]) | unique | list %}
-{%     for c in columns %}
-{%         if c in found_columns %}
+{% set columns = ["variable", "default", "description", "type", "deprecated", "example"] %}
+{% set found_columns = ["variable", "default"] + var.values() | map("list") | sum(start=["key"]) | unique | list %}
+{% for c in columns %}
+{% if c in found_columns %}
 | {{ c | capitalize }} {# trimnewline #}
-{%         endif %}
-{%     endfor %}
+{% endif %}
+{% endfor %}
 |
-{%     for c in columns %}
-{%         if c in found_columns %}
+{% for c in columns %}
+{% if c in found_columns %}
 | {{ "-" * c | length }} {# trimnewline #}
-{%         endif %}
-{%     endfor %}
+{% endif %}
+{% endfor %}
 |
-{%     for key, item in var | dictsort %}
+{% for key, item in var | dictsort %}
 | {{ key }} {# trimnewline #}
 | {{ (item.value | default({}))[key] | default }} {# trimnewline #}
-{%         if "description" in found_columns %}
+{% if "description" in found_columns %}
 | {{ item.description | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
-{%         endif %}
-{%         if "type" in found_columns %}
+{% endif %}
+{% if "type" in found_columns %}
 | {{ item.type | default([]) | join("<br>") }} {# trimnewline #}
-{%         endif %}
-{%         if "deprecated" in found_columns %}
+{% endif %}
+{% if "deprecated" in found_columns %}
 | {{ item.deprecated | default }} {# trimnewline #}
-{%         endif %}
-{%         if "example" in found_columns %}
+{% endif %}
+{% if "example" in found_columns %}
 | {{ item.example | default([]) | safe_join("<br>") | replace("\n", "<br>") | replace("|", "\|") }} {# trimnewline #}
-{%         endif %}
+{% endif %}
 |
-{%     endfor %}
+{% endfor %}
 {% endif %}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -12,7 +12,7 @@
 |
 {% for c in columns %}
 {% if c in found_columns %}
-| {{ "-" * c | length }} {# trimnewline #}
+| {{ "-" * (c | length) }} {# trimnewline #}
 {% endif %}
 {% endfor %}
 |


### PR DESCRIPTION
# Description

Adding an configuration option which will render the Default Variables in a Markdown table rather than in separate sub-headings.

# Usage

```yaml
# .ansibledoctor.yml
template: readme
tabulate_variables: true
```

# Notes

* The generated table dynamically determines which columns to include (i.e. if there are no variable "types" defined, there will be no Types column.
* `|` characters are escaped
* `\n` characters are converted into `<br>` characters
* The Table of Contents will not contain the list of variables if `tabulate_variables` is set to `true`
* This functionality was not added to the `hugo-book` template, but can be done so easily

# Example

## Defaults/main.yml

```yaml
# defaults/main.yml
# @var join_the_dark_side:description: >
# Join the dark side, we have cookies
# @end
# @var join_the_dark_side:type: boolean
join_the_dark_side: true

# @var lighsaber_color:description: >
# The color of your lightsaber
# Options:
#   * red
#   * blue
#   * green
#   * purple
# @end
# @var lighsaber_color:type: string
lighsaber_color: red

# @var padawans:description: >
# List of padawans to train
# @end
# @var padawans:type: list(string)
padawans: []
```

## Output

### Text

```
| Variable | Default | Description | Type |
| -------- | ------- | ----------- | ---- |
| join_the_dark_side | True | Join the dark side, we have cookies | boolean |
| lighsaber_color | red | The color of your lightsaber<br>Options:<br> * red<br> * blue<br> * green<br> * purple | string |
| padawans | [] | List of padawans to train | list(string) |
```

### Rendered

| Variable | Default | Description | Type |
| -------- | ------- | ----------- | ---- |
| join_the_dark_side | True | Join the dark side, we have cookies | boolean |
| lighsaber_color | red | The color of your lightsaber<br>Options:<br> * red<br> * blue<br> * green<br> * purple | string |
| padawans | [] | List of padawans to train | list(string) |


