### PR TITLE
Use lowercase for `Default` column

### DIFF
--- a/ansibledoctor/templates/readme/_vars.j2
+++ b/ansibledoctor/templates/readme/_vars.j2
@@ -31,7 +31,7 @@
 
 ```YAML
 {% if item.value is mapping %}
-{{ item.value | to_nice_yaml(indent=2) }}
+{{ item.value | lower | to_nice_yaml(indent=2) }}
 {% else %}
 {% for ve_line in item.value %}
 {{ ve_line | replace("\n\n", "\n") }}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -18,7 +18,7 @@
 |
 {% for key, item in var | dictsort %}
 |{{ key -}}
-|{{ (item.value | default({}))[key] | default -}}
+|{{ (item.value | default({}))[key] | lower | default -}}
 {% if "description" in found_columns %}
 |{{ item.description | default([]) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
 {% endif %}


### PR DESCRIPTION
This avoids that boolean values get capitalized by default during the jinja2 parsing, i.e. `true/false` instead of `True/False`.