### PR TITLE
feat: add to_code filter and enable codeblocks for tabulated vars

### DIFF
--- a/ansibledoctor/doc_generator.py
+++ b/ansibledoctor/doc_generator.py
@@ -96,6 +96,7 @@ class Generator:
                                 autoescape=jinja2.select_autoescape(),
                             )
                             jenv.filters["to_nice_yaml"] = self._to_nice_yaml
+                            jenv.filters["to_code"] = self._to_code
                             jenv.filters["deep_get"] = self._deep_get
                             jenv.filters["safe_join"] = self._safe_join
                             # keep the old name of the function to not break custom templates.
@@ -126,6 +127,25 @@ class Generator:
         stream = ruamel.yaml.compat.StringIO()
         yaml.dump(a, stream, **kw)
         return stream.getvalue().rstrip()
+
+    def _to_code(self, a, to_multiline=False, skip_list_len=0, lang="plain"):
+        """Wrap a string in backticks."""
+        if a is None or a == "":
+            return ""
+
+        if (isinstance(a, list) and len(a) < 1) or (isinstance(a, dict) and not a):
+            return ""
+
+        if isinstance(a, list) and len(a) == 1:
+            return f"`{a[0]}`"
+
+        if isinstance(a, list) and skip_list_len > 0 and len(a) > skip_list_len:
+            return a
+
+        if (isinstance(a, list)) and to_multiline:
+            return f"```{lang}\n{'\n'.join(a)}\n```"
+
+        return f"`{a}`"
 
     def _deep_get(self, _, dictionary, keys):
         default = None

--- a/ansibledoctor/doc_generator.py
+++ b/ansibledoctor/doc_generator.py
@@ -143,7 +143,7 @@ class Generator:
             return a
 
         if (isinstance(a, list)) and to_multiline:
-            return f"```{lang}\n{'\n'.join(a)}\n```"
+            return "```" + lang + "\n" + "\n".join(a) + "\n```"
 
         return f"`{a}`"
 

--- a/ansibledoctor/templates/hugo-book/_vars_tabulated.j2
+++ b/ansibledoctor/templates/hugo-book/_vars_tabulated.j2
@@ -17,13 +17,13 @@
 {% endfor %}
 |
 {% for key, item in var | dictsort %}
-|{{ key -}}
-|{{ (item.value | default({}))[key] | default -}}
+|{{ key | to_code -}}
+|{{ (item.value | default({}))[key] | default | to_code -}}
 {% if "description" in found_columns %}
 |{{ item.description | default([]) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
 {% endif %}
 {% if "type" in found_columns %}
-|{{ item.type | default([]) | join("<br />") -}}
+|{{ item.type | default([]) | to_code(skip_list_len=1) | safe_join("<br />") -}}
 {% endif %}
 {% if "deprecated" in found_columns %}
 |
@@ -42,7 +42,7 @@ False
 {% endif %}
 {% endif %}
 {% if "example" in found_columns %}
-|{{ item.example | default([]) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
+|{{ item.example | default([]) | to_code(skip_list_len=1) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
 {% endif %}
 |
 {% endfor %}

--- a/ansibledoctor/templates/readme/_vars_tabulated.j2
+++ b/ansibledoctor/templates/readme/_vars_tabulated.j2
@@ -17,13 +17,13 @@
 {% endfor %}
 |
 {% for key, item in var | dictsort %}
-|{{ key -}}
-|{{ (item.value | default({}))[key] | default -}}
+|{{ key | to_code -}}
+|{{ (item.value | default({}))[key] | default | to_code -}}
 {% if "description" in found_columns %}
 |{{ item.description | default([]) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
 {% endif %}
 {% if "type" in found_columns %}
-|{{ item.type | default([]) | join("<br />") -}}
+|{{ item.type | default([]) | to_code(skip_list_len=1) | safe_join("<br />") -}}
 {% endif %}
 {% if "deprecated" in found_columns %}
 |
@@ -42,7 +42,7 @@ False
 {% endif %}
 {% endif %}
 {% if "example" in found_columns %}
-|{{ item.example | default([]) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
+|{{ item.example | default([]) | to_code(skip_list_len=1) | safe_join("<br />") | replace("\n", "<br />") | replace("|", "\|") -}}
 {% endif %}
 |
 {% endfor %}

--- a/example/demo-role/README.md
+++ b/example/demo-role/README.md
@@ -10,18 +10,6 @@ the default description with an annotation.
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
-  - [demo_bool](#demo_bool)
-  - [demo_role_deprecated](#demo_role_deprecated)
-  - [demo_role_deprecated_info](#demo_role_deprecated_info)
-  - [demo_role_dict](#demo_role_dict)
-  - [demo_role_empty](#demo_role_empty)
-  - [demo_role_empty_dict](#demo_role_empty_dict)
-  - [demo_role_other_tags](#demo_role_other_tags)
-  - [demo_role_override](#demo_role_override)
-  - [demo_role_override_complex](#demo_role_override_complex)
-  - [demo_role_single](#demo_role_single)
-  - [demo_role_undefined_var](#demo_role_undefined_var)
-  - [demo_role_unset](#demo_role_unset)
 - [Discovered Tags](#discovered-tags)
 - [Open Tasks](#open-tasks)
 - [Dependencies](#dependencies)
@@ -36,170 +24,20 @@ the default description with an annotation.
 
 ## Default Variables
 
-### demo_bool
-
-#### Default value
-
-```YAML
-demo_bool: true
-```
-
-#### Example usage
-
-```YAML
-demo_bool: false
-```
-
-### demo_role_deprecated
-
-**_Deprecated_**<br />
-
-#### Default value
-
-```YAML
-demo_role_deprecated: b
-```
-
-### demo_role_deprecated_info
-
-**_Deprecated:_** This variable is deprected since `v2.0.0` and will be removed in a future release.<br />
-**_Type:_** string<br />
-
-#### Default value
-
-```YAML
-demo_role_deprecated_info: a
-```
-
-### demo_role_dict
-
-#### Default value
-
-```YAML
-demo_role_dict:
-  key1:
-    sub: some value
-```
-
-#### Example usage
-
-```YAML
-demo_role_dict:
-  key1:
-    sub: some value
-
-  # Inline description
-  key2:
-    sublist:
-      - subval1
-      - subval2
-```
-
-### demo_role_empty
-
-#### Default value
-
-```YAML
-demo_role_empty: ''
-```
-
-### demo_role_empty_dict
-
-... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key
-and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.
-
-#### Default value
-
-```YAML
-demo_role_empty_dict: {}
-```
-
-#### Example usage
-
-```YAML
-demo_role_empty_dict:
-  key1:
-    sub: some value
-  key2:
-    sublist:
-      - subval1
-      - subval2
-```
-
-### demo_role_other_tags
-
-If a variable need some more explanation, this is a good place to do so.
-
-#### Default value
-
-```YAML
-demo_role_other_tags: []
-```
-
-#### Example usage
-
-```YAML
-demo_role_other_tags:
-  - package1
-  - package2
-```
-
-### demo_role_override
-
-#### Default value
-
-```YAML
-demo_role_override: test
-```
-
-### demo_role_override_complex
-
-#### Default value
-
-```YAML
-demo_role_override_complex:
-  foo: bar
-  second: value
-```
-
-### demo_role_single
-
-#### Default value
-
-```YAML
-demo_role_single: b
-```
-
-### demo_role_undefined_var
-
-To highlight a variable that has not set a value by default, this is one way to achieve it.
-Make sure to flag it as json value: `@var demo_role_undefined_var: $ "_unset_"`
-
-| Attribute | Description |
-| --- | --- |
-| value1 | desc1 |
-
-#### Default value
-
-```YAML
-demo_role_undefined_var: _unset_
-```
-
-### demo_role_unset
-
-Values can be plain strings, but there is no magic or autoformatting...
-
-#### Default value
-
-```YAML
-demo_role_unset:
-```
-
-#### Example usage
-
-```YAML
-demo_role_unset: some_value
-```
+|Variable|Default|Description|Type|Deprecated|Example|
+|--------|-------|-----------|----|----------|-------|
+|demo_bool|True|||False|demo_bool|
+|demo_role_deprecated|b|||True||
+|demo_role_deprecated_info|a||string|This variable is deprected since `v2.0.0` and will be removed in a future release.||
+|demo_role_dict|{'key1': {'sub': 'some value'}}|||False|demo_role_dict:<br /> key1:<br /> sub: some value<br /><br /><br /># Inline description<br /> key2:<br /> sublist:<br /> - subval1<br /> - subval2|
+|demo_role_empty||||False||
+|demo_role_empty_dict|{}|... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key<br />and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.||False|demo_role_empty_dict|
+|demo_role_other_tags|[]|If a variable need some more explanation, this is a good place to do so.||False|demo_role_other_tags|
+|demo_role_override|test|||False||
+|demo_role_override_complex|{'foo': 'bar', 'second': 'value'}|||False||
+|demo_role_single|b|||False||
+|demo_role_undefined_var|_unset_|To highlight a variable that has not set a value by default, this is one way to achieve it.<br />Make sure to flag it as json value: `@var demo_role_undefined_var: $ "_unset_"`<br /><br /><br />\| Attribute \| Description \|<br />\| --- \| --- \|<br />\| value1 \| desc1 \|||False||
+|demo_role_unset|None|Values can be plain strings, but there is no magic or autoformatting...||False|demo_role_unset: some_value|
 
 ## Discovered Tags
 

--- a/example/demo-role/README.md
+++ b/example/demo-role/README.md
@@ -10,6 +10,18 @@ the default description with an annotation.
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
+  - [demo_bool](#demo_bool)
+  - [demo_role_deprecated](#demo_role_deprecated)
+  - [demo_role_deprecated_info](#demo_role_deprecated_info)
+  - [demo_role_dict](#demo_role_dict)
+  - [demo_role_empty](#demo_role_empty)
+  - [demo_role_empty_dict](#demo_role_empty_dict)
+  - [demo_role_other_tags](#demo_role_other_tags)
+  - [demo_role_override](#demo_role_override)
+  - [demo_role_override_complex](#demo_role_override_complex)
+  - [demo_role_single](#demo_role_single)
+  - [demo_role_undefined_var](#demo_role_undefined_var)
+  - [demo_role_unset](#demo_role_unset)
 - [Discovered Tags](#discovered-tags)
 - [Open Tasks](#open-tasks)
 - [Dependencies](#dependencies)
@@ -24,20 +36,170 @@ the default description with an annotation.
 
 ## Default Variables
 
-|Variable|Default|Description|Type|Deprecated|Example|
-|--------|-------|-----------|----|----------|-------|
-|demo_bool|True|||False|demo_bool|
-|demo_role_deprecated|b|||True||
-|demo_role_deprecated_info|a||string|This variable is deprected since `v2.0.0` and will be removed in a future release.||
-|demo_role_dict|{'key1': {'sub': 'some value'}}|||False|demo_role_dict:<br /> key1:<br /> sub: some value<br /><br /><br /># Inline description<br /> key2:<br /> sublist:<br /> - subval1<br /> - subval2|
-|demo_role_empty||||False||
-|demo_role_empty_dict|{}|... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key<br />and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.||False|demo_role_empty_dict|
-|demo_role_other_tags|[]|If a variable need some more explanation, this is a good place to do so.||False|demo_role_other_tags|
-|demo_role_override|test|||False||
-|demo_role_override_complex|{'foo': 'bar', 'second': 'value'}|||False||
-|demo_role_single|b|||False||
-|demo_role_undefined_var|_unset_|To highlight a variable that has not set a value by default, this is one way to achieve it.<br />Make sure to flag it as json value: `@var demo_role_undefined_var: $ "_unset_"`<br /><br /><br />\| Attribute \| Description \|<br />\| --- \| --- \|<br />\| value1 \| desc1 \|||False||
-|demo_role_unset|None|Values can be plain strings, but there is no magic or autoformatting...||False|demo_role_unset: some_value|
+### demo_bool
+
+#### Default value
+
+```YAML
+demo_bool: true
+```
+
+#### Example usage
+
+```YAML
+demo_bool: false
+```
+
+### demo_role_deprecated
+
+**_Deprecated_**<br />
+
+#### Default value
+
+```YAML
+demo_role_deprecated: b
+```
+
+### demo_role_deprecated_info
+
+**_Deprecated:_** This variable is deprected since `v2.0.0` and will be removed in a future release.<br />
+**_Type:_** string<br />
+
+#### Default value
+
+```YAML
+demo_role_deprecated_info: a
+```
+
+### demo_role_dict
+
+#### Default value
+
+```YAML
+demo_role_dict:
+  key1:
+    sub: some value
+```
+
+#### Example usage
+
+```YAML
+demo_role_dict:
+  key1:
+    sub: some value
+
+  # Inline description
+  key2:
+    sublist:
+      - subval1
+      - subval2
+```
+
+### demo_role_empty
+
+#### Default value
+
+```YAML
+demo_role_empty: ''
+```
+
+### demo_role_empty_dict
+
+... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key
+and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.
+
+#### Default value
+
+```YAML
+demo_role_empty_dict: {}
+```
+
+#### Example usage
+
+```YAML
+demo_role_empty_dict:
+  key1:
+    sub: some value
+  key2:
+    sublist:
+      - subval1
+      - subval2
+```
+
+### demo_role_other_tags
+
+If a variable need some more explanation, this is a good place to do so.
+
+#### Default value
+
+```YAML
+demo_role_other_tags: []
+```
+
+#### Example usage
+
+```YAML
+demo_role_other_tags:
+  - package1
+  - package2
+```
+
+### demo_role_override
+
+#### Default value
+
+```YAML
+demo_role_override: test
+```
+
+### demo_role_override_complex
+
+#### Default value
+
+```YAML
+demo_role_override_complex:
+  foo: bar
+  second: value
+```
+
+### demo_role_single
+
+#### Default value
+
+```YAML
+demo_role_single: b
+```
+
+### demo_role_undefined_var
+
+To highlight a variable that has not set a value by default, this is one way to achieve it.
+Make sure to flag it as json value: `@var demo_role_undefined_var: $ "_unset_"`
+
+| Attribute | Description |
+| --- | --- |
+| value1 | desc1 |
+
+#### Default value
+
+```YAML
+demo_role_undefined_var: _unset_
+```
+
+### demo_role_unset
+
+Values can be plain strings, but there is no magic or autoformatting...
+
+#### Default value
+
+```YAML
+demo_role_unset:
+```
+
+#### Example usage
+
+```YAML
+demo_role_unset: some_value
+```
 
 ## Discovered Tags
 

--- a/example/other-role/README.md
+++ b/example/other-role/README.md
@@ -145,7 +145,9 @@ If a variable need some more explanation, this is a good place to do so.
 #### Default value
 
 ```YAML
-other_role_other_tags: []
+other_role_other_tags:
+  - package1
+  - package2
 ```
 
 #### Example usage

--- a/example/other-role/README.md
+++ b/example/other-role/README.md
@@ -9,6 +9,19 @@ Role to demonstrate ansible-doctor.
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
+  - [demo_bool](#demo_bool)
+  - [other_role_deprecated](#other_role_deprecated)
+  - [other_role_deprecated_info](#other_role_deprecated_info)
+  - [other_role_dict](#other_role_dict)
+  - [other_role_empty](#other_role_empty)
+  - [other_role_empty_dict](#other_role_empty_dict)
+  - [other_role_multiline_type](#other_role_multiline_type)
+  - [other_role_other_tags](#other_role_other_tags)
+  - [other_role_override](#other_role_override)
+  - [other_role_override_complex](#other_role_override_complex)
+  - [other_role_single](#other_role_single)
+  - [other_role_undefined_var](#other_role_undefined_var)
+  - [other_role_unset](#other_role_unset)
 - [Discovered Tags](#discovered-tags)
 - [Open Tasks](#open-tasks)
 - [Dependencies](#dependencies)
@@ -23,21 +36,182 @@ Role to demonstrate ansible-doctor.
 
 ## Default Variables
 
-|Variable|Default|Description|Type|Deprecated|Example|
-|--------|-------|-----------|----|----------|-------|
-|`demo_bool`|`True`|||False|`{'demo_bool': False}`|
-|`other_role_deprecated`|`b`|||True||
-|`other_role_deprecated_info`|`a`||`string`|This variable is deprected since `v2.0.0` and will be removed in a future release.||
-|`other_role_dict`|`{'key1': {'sub': 'some value'}}`|||False|other_role_dict:<br /> key1:<br /> sub: some value<br /><br /><br /># Inline description<br /> key2:<br /> sublist:<br /> - subval1<br /> - subval2|
-|`other_role_empty`||||False||
-|`other_role_empty_dict`||... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key<br />and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.||False|`{'other_role_empty_dict': {'key1': {'sub': 'some value'}, 'key2': {'sublist': ['subval1', 'subval2']}}}`|
-|`other_role_multiline_type`|`a`||string<br />list<br />dict|False||
-|`other_role_other_tags`||If a variable need some more explanation, this is a good place to do so.||False|`{'other_role_other_tags': ['package1', 'package2']}`|
-|`other_role_override`|`test`|||False||
-|`other_role_override_complex`|`{'foo': 'bar', 'second': 'value'}`|||False||
-|`other_role_single`|`b`|||False||
-|`other_role_undefined_var`|`_unset_`|To highlight a variable that has not set a value by default, this is one way to achieve it.<br />Make sure to flag it as json value: `@var other_role_undefined_var: $ "_unset_"`<br /><br /><br />\| Attribute \| Description \|<br />\| --- \| --- \|<br />\| value1 \| desc1 \|||False||
-|`other_role_unset`||Values can be plain strings, but there is no magic or autoformatting...||False|`other_role_unset: some_value`|
+### demo_bool
+
+#### Default value
+
+```YAML
+demo_bool: true
+```
+
+#### Example usage
+
+```YAML
+demo_bool: false
+```
+
+### other_role_deprecated
+
+**_Deprecated_**<br />
+
+#### Default value
+
+```YAML
+other_role_deprecated: b
+```
+
+### other_role_deprecated_info
+
+**_Deprecated:_** This variable is deprected since `v2.0.0` and will be removed in a future release.<br />
+**_Type:_** string<br />
+
+#### Default value
+
+```YAML
+other_role_deprecated_info: a
+```
+
+### other_role_dict
+
+#### Default value
+
+```YAML
+other_role_dict:
+  key1:
+    sub: some value
+```
+
+#### Example usage
+
+```YAML
+other_role_dict:
+  key1:
+    sub: some value
+
+  # Inline description
+  key2:
+    sublist:
+      - subval1
+      - subval2
+```
+
+### other_role_empty
+
+#### Default value
+
+```YAML
+other_role_empty: ''
+```
+
+### other_role_empty_dict
+
+... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key
+and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.
+
+#### Default value
+
+```YAML
+other_role_empty_dict: {}
+```
+
+#### Example usage
+
+```YAML
+other_role_empty_dict:
+  key1:
+    sub: some value
+  key2:
+    sublist:
+      - subval1
+      - subval2
+```
+
+### other_role_multiline_type
+
+**_Type:_** string
+list
+dict<br />
+
+#### Default value
+
+```YAML
+other_role_multiline_type: a
+```
+
+### other_role_other_tags
+
+If a variable need some more explanation, this is a good place to do so.
+
+#### Default value
+
+```YAML
+other_role_other_tags: []
+```
+
+#### Example usage
+
+```YAML
+other_role_other_tags:
+  - package1
+  - package2
+```
+
+### other_role_override
+
+#### Default value
+
+```YAML
+other_role_override: test
+```
+
+### other_role_override_complex
+
+#### Default value
+
+```YAML
+other_role_override_complex:
+  foo: bar
+  second: value
+```
+
+### other_role_single
+
+#### Default value
+
+```YAML
+other_role_single: b
+```
+
+### other_role_undefined_var
+
+To highlight a variable that has not set a value by default, this is one way to achieve it.
+Make sure to flag it as json value: `@var other_role_undefined_var: $ "_unset_"`
+
+| Attribute | Description |
+| --- | --- |
+| value1 | desc1 |
+
+#### Default value
+
+```YAML
+other_role_undefined_var: _unset_
+```
+
+### other_role_unset
+
+Values can be plain strings, but there is no magic or autoformatting...
+
+#### Default value
+
+```YAML
+other_role_unset:
+```
+
+#### Example usage
+
+```YAML
+other_role_unset: some_value
+```
 
 ## Discovered Tags
 

--- a/example/other-role/README.md
+++ b/example/other-role/README.md
@@ -9,7 +9,6 @@ Role to demonstrate ansible-doctor.
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
-  - [demo_role_unset](#demo_role_unset)
 - [Discovered Tags](#discovered-tags)
 - [Open Tasks](#open-tasks)
 - [Dependencies](#dependencies)
@@ -24,21 +23,21 @@ Role to demonstrate ansible-doctor.
 
 ## Default Variables
 
-### demo_role_unset
-
-Values can be plain strings, but there is no magic or autoformatting...
-
-#### Default value
-
-```YAML
-demo_role_unset:
-```
-
-#### Example usage
-
-```YAML
-demo_role_unset: some_value
-```
+|Variable|Default|Description|Type|Deprecated|Example|
+|--------|-------|-----------|----|----------|-------|
+|`demo_bool`|`True`|||False|`{'demo_bool': False}`|
+|`other_role_deprecated`|`b`|||True||
+|`other_role_deprecated_info`|`a`||`string`|This variable is deprected since `v2.0.0` and will be removed in a future release.||
+|`other_role_dict`|`{'key1': {'sub': 'some value'}}`|||False|other_role_dict:<br /> key1:<br /> sub: some value<br /><br /><br /># Inline description<br /> key2:<br /> sublist:<br /> - subval1<br /> - subval2|
+|`other_role_empty`||||False||
+|`other_role_empty_dict`||... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key<br />and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.||False|`{'other_role_empty_dict': {'key1': {'sub': 'some value'}, 'key2': {'sublist': ['subval1', 'subval2']}}}`|
+|`other_role_multiline_type`|`a`||string<br />list<br />dict|False||
+|`other_role_other_tags`||If a variable need some more explanation, this is a good place to do so.||False|`{'other_role_other_tags': ['package1', 'package2']}`|
+|`other_role_override`|`test`|||False||
+|`other_role_override_complex`|`{'foo': 'bar', 'second': 'value'}`|||False||
+|`other_role_single`|`b`|||False||
+|`other_role_undefined_var`|`_unset_`|To highlight a variable that has not set a value by default, this is one way to achieve it.<br />Make sure to flag it as json value: `@var other_role_undefined_var: $ "_unset_"`<br /><br /><br />\| Attribute \| Description \|<br />\| --- \| --- \|<br />\| value1 \| desc1 \|||False||
+|`other_role_unset`||Values can be plain strings, but there is no magic or autoformatting...||False|`other_role_unset: some_value`|
 
 ## Discovered Tags
 

--- a/example/other-role/defaults/main.yml
+++ b/example/other-role/defaults/main.yml
@@ -1,4 +1,77 @@
 ---
-# @var demo_role_unset:description: Values can be plain strings, but there is no magic or autoformatting...
-# @var demo_role_unset:example: demo_role_unset: some_value
-demo_role_unset:
+# @var other_role_unset:description: Values can be plain strings, but there is no magic or autoformatting...
+# @var other_role_unset:example: other_role_unset: some_value
+other_role_unset:
+
+other_role_empty: ""
+other_role_single: "b"
+
+# @var demo_bool:example: $ false
+demo_bool: true
+
+# @var other_role_empty_dict:description: >
+# ... or valid json can be used. In this case, the json will be automatically prefixed with the annotation key
+# and filters like `to_nice_yaml` can be used in templates. To get it working, the json need to be prefixed with a `$`.
+# @end
+# @var other_role_empty_dict:example: $ {"key1": {"sub": "some value"}, "key2": {"sublist": ["subval1", "subval2"]}}
+other_role_empty_dict: {}
+
+# @var other_role_dict:example: >
+# other_role_dict:
+#   key1:
+#     sub: some value
+#
+#   # Inline description
+#   key2:
+#     sublist:
+#       - subval1
+#       - subval2
+# @end
+other_role_dict:
+  key1:
+    sub: some value
+
+# @var other_role_undefined_var:description: >
+# To highlight a variable that has not set a value by default, this is one way to achieve it.
+# Make sure to flag it as json value: `@var other_role_undefined_var: $ "_unset_"`
+#
+# | Attribute | Description |
+# | --- | --- |
+# | value1 | desc1 |
+#
+# @end
+# @var other_role_undefined_var: $ "_unset_"
+
+# @var other_role_other_tags:description: >
+# If a variable need some more explanation, this is a good place to do so.
+# @end
+# @var other_role_other_tags:example: $>
+# [
+#   "package1",
+#   "package2"
+# ]
+# @end
+other_role_other_tags: []
+
+## Simple value
+# @var other_role_override: $ "test"
+other_role_override: original
+
+## Complex value
+# @var other_role_override_complex:value: $ {"foo":"bar", "second":"value"}
+other_role_override_complex: {}
+
+# @var other_role_deprecated:deprecated:
+other_role_deprecated: "b"
+
+# @var other_role_deprecated_info:deprecated: >
+# This variable is deprected since `v2.0.0` and will be removed in a future release.
+# @var other_role_deprecated_info:type: string
+other_role_deprecated_info: "a"
+
+# @var other_role_multiline_type:type: >
+# string
+# list
+# dict
+# @end
+other_role_multiline_type: "a"

--- a/example/other-role/defaults/main.yml
+++ b/example/other-role/defaults/main.yml
@@ -51,6 +51,7 @@ other_role_dict:
 #   "package2"
 # ]
 # @end
+# @var other_role_other_tags:value: $ ["package1", "package2"]
 other_role_other_tags: []
 
 ## Simple value


### PR DESCRIPTION
Alternative approach to https://github.com/thegeeklab/ansible-doctor/pull/780. Still not perfect and a bit fiddly:

![image](https://github.com/user-attachments/assets/661c092b-fd79-4703-8065-500617240f51)
