### PR TITLE
Add base_dir in templates search path

### DIFF
--- a/ansibledoctor/doc_generator.py
+++ b/ansibledoctor/doc_generator.py
@@ -91,7 +91,10 @@ class Generator:
                     if data is not None:
                         try:
                             jenv = Environment(  # nosec
-                                loader=FileSystemLoader(self.template.path),
+                                loader=FileSystemLoader([
+                                    self.template.path,
+                                    self.config.args['base_dir']
+                                    ]),
                                 lstrip_blocks=True,
                                 trim_blocks=True,
                                 autoescape=jinja2.select_autoescape(),


### PR DESCRIPTION
After discussion in issue #845, this merge request adds role base_dir in jinja search path so that when a template includes a file, the file to include can be found in role directory.