### PR TITLE
chore: changed `Table of content` to `Table of contents` in templates and docs

### DIFF
--- a/ansibledoctor/templates/readme/_toc.j2
+++ b/ansibledoctor/templates/readme/_toc.j2
@@ -1,4 +1,4 @@
-## Table of content
+## Table of contents
 
 - [Requirements](#requirements)
 {% set var = role.var | default({}) %}

--- a/example/demo-role/README.md
+++ b/example/demo-role/README.md
@@ -6,7 +6,7 @@
 Role to demonstrate ansible-doctor. It is also possible to overwrite
 the default description with an annotation.
 
-## Table of content
+## Table of contents
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)

--- a/example/other-role/README.md
+++ b/example/other-role/README.md
@@ -5,7 +5,7 @@
 
 Role to demonstrate ansible-doctor.
 
-## Table of content
+## Table of contents
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)


### PR DESCRIPTION
Proposed fix for #975 - "Table of content" should be "Table of contents"

Three changes, can't imagine any safety issues with them. As this is a question of style I will understand if the decision is made not to accept the change.