### PR TITLE
fix: make base_dir and OUTPUT_PATH more robust

### DIFF
--- a/ansibledoctor/cli.py
+++ b/ansibledoctor/cli.py
@@ -45,6 +45,7 @@ class AnsibleDoctor:
             "base_dir",
             nargs="?",
             default=self.config.config.base_dir,
+            type=valid_directory,
             help="base directory (default: current working directory)",
         )
         parser.add_argument(
@@ -142,6 +143,19 @@ class AnsibleDoctor:
             doc_parser = Parser()
             doc_generator = Generator(doc_parser)
             doc_generator.render()
+
+
+def valid_directory(path):
+    """
+    Validate that the provided path is a directory.
+
+    :param path: Path to validate
+    :return: Validated path
+    :raises argparse.ArgumentTypeError: If path is not a directory
+    """
+    if not os.path.isdir(path):
+        raise argparse.ArgumentTypeError(f"Path '{path}' is not a directory")
+    return path
 
 
 def main():

--- a/ansibledoctor/config.py
+++ b/ansibledoctor/config.py
@@ -262,7 +262,12 @@ class Config:
 
     def get_output_path(self, template_file):
         """Get the output file path for a template file."""
-        dest_path = self.config.get("renderer.dest")
+        dest_path = os.path.normpath(self.config.get("renderer.dest"))
+
+        # Ensure the path is either absolute or a valid relative path
+        if not os.path.isabs(dest_path):
+            dest_path = os.path.normpath(os.path.join(os.getcwd(), dest_path))
+
         dest_dir, dest_file = self._parse_output_path(dest_path)
 
         if dest_file:


### PR DESCRIPTION
Related-to: https://github.com/thegeeklab/ansible-doctor/issues/987

This fix is not directly related to the liked issue but improves the error handling and sanitizing for the user inputs `base_dir` and `OUTPUT_PATH`.